### PR TITLE
exclude rdsadmin

### DIFF
--- a/dailybackup.py
+++ b/dailybackup.py
@@ -51,7 +51,7 @@ cursor = conn.cursor()
 cursor.execute(
     """
     SELECT datname FROM pg_database
-    WHERE datistemplate = false AND datname != 'postgres';
+    WHERE datistemplate = false AND datname != 'postgres' AND datname != 'rdsadmin';
 """
 )
 databases = [row[0] for row in cursor.fetchall()]


### PR DESCRIPTION
exclude the `rdsadmin` database from the list to be backed up

this is to fix the error we were seeing in the logs:

```
PID 546580 stream output:
pg_dump: error: connection to server at "**********.ap-south-1.rds.amazonaws.com" (******), port 5432 failed: FATAL:  pg_hba.conf rejects connection for host "**********", user "postgres", database "rdsadmin", no encryption
connection to server at "******************.ap-south-1.rds.amazonaws.com" (*********), port 5432 failed: SSL error: certificate verify failed
```